### PR TITLE
Gate could be already present on the disk

### DIFF
--- a/.github/workflows/runTest.sh
+++ b/.github/workflows/runTest.sh
@@ -56,15 +56,16 @@ cd /software/gate
 if [ -z "$COMMIT" ]; then
     COMMIT="develop"
 fi
-git clone --branch ${COMMIT} https://github.com/OpenGATE/Gate.git src
+if [ ! -d /src ]; then
+  git clone --branch ${COMMIT} https://github.com/OpenGATE/Gate.git /src
+fi
 cd bin
 cmake -DGATE_USE_TORCH=$GATE_USE_TORCH \
       -DTorch_DIR=$TORCH_DIR \
       -DGATE_USE_OPTICAL=$USE_OPTICAL \
-      ../src
+      /src
 make -j4
 cd ..
-rm -rf src
 source /etc/mybashrc
 echo 'export PATH=/software/gatetools/clustertools/:$PATH' >> /etc/mybashrc
 echo 'export PATH=/software/gate/bin:$PATH' >> /etc/mybashrc


### PR DESCRIPTION
For PR inside Gate repository, do not clone the Gate repository because it's not the wanted version. Use the Gate version inside /src directory, mounted by Docker