### PR TITLE
Update runTest.sh

### DIFF
--- a/.github/workflows/runTest.sh
+++ b/.github/workflows/runTest.sh
@@ -85,6 +85,7 @@ source /etc/mybashrc
 cd /home/
 export LC_ALL=en_US.utf8
 export LANG=en_US.utf8
+pip3 install "scipy<1.18.0"
 pip3 install click colorama "numpy<2.0.0"
 OutputTest=$(python3 runBenchmark.py -t ${TEST})
 echo "$OutputTest"


### PR DESCRIPTION
With newer version of numpy >2.5.0, we have an error AttributeError: module 'numpy' has no attribute 'long'. Did you mean: 'log'? in scipy code Force the version <2.5.0